### PR TITLE
Correct size of usable SRAM to 128 MB

### DIFF
--- a/boards/arm/teensy4/teensy40.yaml
+++ b/boards/arm/teensy4/teensy40.yaml
@@ -12,7 +12,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 32768
+ram: 128
 flash: 2048
 supported:
   - counter

--- a/boards/arm/teensy4/teensy41.yaml
+++ b/boards/arm/teensy4/teensy41.yaml
@@ -12,7 +12,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 32768
+ram: 128
 flash: 8192
 supported:
   - counter


### PR DESCRIPTION
I think the RAM size in this file is used for the unit tests. It is not directly related to the physically available RAM.